### PR TITLE
Divide screen into sections

### DIFF
--- a/src/components/JournalSections.js
+++ b/src/components/JournalSections.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import { Text, View, TouchableOpacity } from 'react-native';
+import { Card, CardSection } from './common';
+import AllJournals from '../containers/AllJournals';
+
+
+export default class JournalSections extends Component {
+  renderAllJournals() {
+    return (<AllJournals />);
+  }
+
+  render() {
+    return (
+        <View>
+          <TouchableOpacity 
+          onPress={() => {
+          this.props.navigation.navigate('AllJournals');
+        }}>
+          <Card >
+            <CardSection style={{ height: 100, borderBottomWidth: 0, paddingBottom: 0, justifyContent: 'center', flexDirection: 'column' }}>
+              <Text style={{ fontSize: 16, textAlign: 'center' }}>
+                Public Journals
+              </Text>
+            </CardSection>
+          </Card>
+          </TouchableOpacity>
+          <TouchableOpacity>
+          <Card>
+            <CardSection style={{ height: 100, borderBottomWidth: 0, paddingBottom: 0, justifyContent: 'center', flexDirection: 'column' }}>
+              <Text style={{ fontSize: 16, textAlign: 'center' }}>
+                Private Journals
+              </Text>
+            </CardSection>
+          </Card>
+          </TouchableOpacity>
+          <TouchableOpacity>
+          <Card>       
+            <CardSection style={{ height: 100, borderBottomWidth: 0, paddingBottom: 0, justifyContent: 'center', flexDirection: 'column' }}>
+              <Text style={{ fontSize: 16, textAlign: 'center' }}>
+                Shared Journals
+              </Text>
+            </CardSection>
+          </Card>
+          </TouchableOpacity>
+        </View>
+    );
+  }
+
+}

--- a/src/screens/JournalSections.js
+++ b/src/screens/JournalSections.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+
+import Icon from 'react-native-vector-icons/SimpleLineIcons';
+import JournalSections from '../components/JournalSections';
+
+
+export default class AllJournalsScreen extends Component<{}> {
+  static navigationOptions = ({ navigation }) => ({
+    title: 'Journal Sections',
+    headerRight: <Icon
+      size={20}
+      style={{ marginRight: 10 }}
+      name={'note'}
+      onPress={() => navigation.navigate('CreateJournal')}
+    />,
+  });
+  render() {
+    return (
+      <JournalSections navigation={this.props.navigation} />
+    );
+  }
+}

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -2,8 +2,10 @@ import { StackNavigator } from 'react-navigation'
 import AllJournals from './AllJournals';
 import Journal from './Journal';
 import CreateJournal from './CreateJournal';
+import JournalSections from './JournalSections';
 
 export default AppNavigator = StackNavigator({
+  JournalSections: { screen: JournalSections },
   AllJournals: { screen: AllJournals },
   Journal: { screen: Journal },
   CreateJournal: { screen: CreateJournal }


### PR DESCRIPTION
This PR fixes a bug with my previous branch. It divides the screen into public, private and shared journals sections. 